### PR TITLE
create netplan configuration for Predictable Network Interface Names

### DIFF
--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -74,5 +74,48 @@ build {
     ]
   }
 
+  provisioner "file" {
+    only = ["qemu.dn"]
+    content     = <<-EOT
+network:
+    version: 2
+    ethernets:
+        all-en:
+            match:
+                name: en*
+            dhcp4: true
+            dhcp4-overrides:
+                use-domains: true
+            dhcp6: true
+            dhcp6-overrides:
+                use-domains: true
+        all-eth:
+            match:
+                name: eth*
+            dhcp4: true
+            dhcp4-overrides:
+                use-domains: true
+            dhcp6: true
+            dhcp6-overrides:
+                use-domains: true
+EOT
+destination = "/tmp/ns8-netplan-debian"
+  }
+
+  provisioner "shell" {
+    only = ["qemu.dn"]
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = ["mv /tmp/ns8-netplan-debian /etc/netplan/50-cloud-init.yaml"]
+  }
+
+  provisioner "shell" {
+    only = ["qemu.dn"]
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = [
+      "netplan generate",
+      "netplan apply",
+    ]
+  }
+
   post-processor "manifest" {}
 }

--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -74,6 +74,12 @@ build {
     ]
   }
 
+  provisioner "shell" {
+    only = ["qemu.dn"]
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = ["rm -f /etc/netplan/*"]
+  }
+
   provisioner "file" {
     only = ["qemu.dn"]
     content     = <<-EOT


### PR DESCRIPTION
Systemd since the version 197 use predictable name  for network Interface

https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
onboard NIC : eno*
pcie card : ens*
physical/geographical location : enp2s*

this is different from the unpredictable network interface name
classical old way : eth*

the root of the issue is that packer create a netplan configuration with a NIC named ens3 that it is not true when you import the qcow2 drive to your hypervisor, named ens18 in my case.

In that context after the boot of the VM we have no network connectivity