### PR TITLE
Update Rocky Linux version and remove cockpit packages

### DIFF
--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -72,6 +72,12 @@ build {
   }
 
   provisioner "shell" {
+    only = ["qemu.rl"]
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = ["dnf remove cockpit-system cockpit-bridge cockpit-ws -y"]
+  }
+
+  provisioner "shell" {
     only = ["qemu.dn"]
     execute_command = "sudo env {{ .Vars }} {{ .Path }}"
     inline = ["rm -f /etc/netplan/*"]

--- a/sources-qemu.pkr.hcl
+++ b/sources-qemu.pkr.hcl
@@ -16,8 +16,8 @@ source "qemu" "dn" {
 }
 
 source "qemu" "rl" {
-  iso_url      = "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.2-20230513.0.x86_64.qcow2"
-  iso_checksum = "sha256:50510f98abe1b20a548102a05a9be83153b0bf634fc502d5c8d1f508f6de1430"
+  iso_url      = "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2"
+  iso_checksum = "sha256:7713278c37f29b0341b0a841ca3ec5c3724df86b4d97e7ee4a2a85def9b2e651"
   disk_image   = true
   headless     = true
   cpu_model    = "host"


### PR DESCRIPTION
This pull request updates the Rocky Linux version to 9.3 and removes the cockpit-system, cockpit-bridge, and cockpit-ws packages using a shell provisioner.

![image](https://github.com/NethServer/ns8-images/assets/3164851/c983e992-7b02-43db-a096-a341f3f9a415)

https://github.com/NethServer/dev/issues/6811