### PR TITLE
Add SWAP file

### DIFF
--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -127,6 +127,16 @@ destination = "/tmp/ns8-netplan-debian"
   }
 
   provisioner "shell" {
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = [
+      "dd if=/dev/zero of=/swapfile bs=1M count=4096",
+      "chmod 600 /swapfile",
+      "mkswap /swapfile",
+      "echo /swapfile   swap    swap    defaults    0 0 >> /etc/fstab"
+    ]
+  }
+
+  provisioner "shell" {
     inline = [
       "sudo rm -rf /root/.ssh /home/debian/.ssh /home/rocky/.ssh || true",
     ]


### PR DESCRIPTION
Optimize memory utilization for nodes hosting numerous containers by introducing a 4GB SWAP file. This adjustment aims to mitigate the likelihood of encountering the Out-of-Memory (OOM) killer.

I'm not sure this the best way to implement it, but it gets the job done.

See https://github.com/NethServer/dev/issues/6824