### PR TITLE
Rebase on Rocky Linux 9.4 image

### DIFF
--- a/sources-qemu.pkr.hcl
+++ b/sources-qemu.pkr.hcl
@@ -16,8 +16,8 @@ source "qemu" "dn" {
 }
 
 source "qemu" "rl" {
-  iso_url      = "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2"
-  iso_checksum = "sha256:7713278c37f29b0341b0a841ca3ec5c3724df86b4d97e7ee4a2a85def9b2e651"
+  iso_url      = "https://dl.rockylinux.org/pub/rocky/9.4/images/x86_64/Rocky-9-GenericCloud-Base-9.4-20240509.0.x86_64.qcow2"
+  iso_checksum = "sha256:2b521fdff4e4d1a0f1a10b53579a34bba8081ce5eb08e64e3ff22289557f0cfa"
   disk_image   = true
   headless     = true
   cpu_model    = "host"


### PR DESCRIPTION
Change the image URL and sha256 checksum for Rocky Linux release 9.4