### PR TITLE
Rebase on Rocky Linux 9.3 image

### DIFF
--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -12,6 +12,17 @@ build {
     ]
   }
 
+
+  provisioner "shell" {
+    only = ["qemu.rl"]
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = [
+      "dnf install -y 'dnf-command(versionlock)'",
+      "dnf versionlock add cloud-init",
+    ]
+  }
+
+
   provisioner "shell" {
     env = {
       "NS8_TWO_STEPS_INSTALL" : "1"
@@ -75,6 +86,15 @@ build {
     only = ["qemu.rl"]
     execute_command = "sudo env {{ .Vars }} {{ .Path }}"
     inline = ["dnf remove cockpit-system cockpit-bridge cockpit-ws -y"]
+  }
+
+  provisioner "shell" {
+    only = ["qemu.rl"]
+    execute_command = "sudo env {{ .Vars }} {{ .Path }}"
+    inline = [
+      "dnf versionlock delete cloud-init",
+      "dnf remove -y 'dnf-command(versionlock)'",
+    ]
   }
 
   provisioner "shell" {

--- a/sources-qemu.pkr.hcl
+++ b/sources-qemu.pkr.hcl
@@ -16,14 +16,13 @@ source "qemu" "dn" {
 }
 
 source "qemu" "rl" {
-  iso_url      = "https://dl.rockylinux.org/pub/rocky/9.4/images/x86_64/Rocky-9-GenericCloud-Base-9.4-20240523.0.x86_64.qcow2"
-  iso_checksum = "sha256:39277948d53a10f1087454a1e0ed1c9bb48b48f6a4ddbf5113adc36f70be6730"
+  iso_url      = "https://dl.rockylinux.org/pub/rocky/9.4/images/x86_64/Rocky-9-GenericCloud-Base-9.4-20240509.0.x86_64.qcow2"
+  iso_checksum = "sha256:2b521fdff4e4d1a0f1a10b53579a34bba8081ce5eb08e64e3ff22289557f0cfa"
   disk_image   = true
   headless     = true
   cpu_model    = "host"
   qemuargs = [
-    ["-smbios", "type=1,serial=ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/"],
-    ["-boot",  "menu=on,splash-time=5000"]
+    ["-smbios", "type=1,serial=ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/"]
   ]
   http_content         = local.cloud-init
   ssh_username         = "rocky"
@@ -32,20 +31,4 @@ source "qemu" "rl" {
   disk_compression     = true
   output_directory     = "qemu_ns8_rl"
   vm_name              = "ns8-rocky-linux-9-${var.core_version}.qcow2"
-  boot_wait            = "4s"
-  boot_command = [
-    "c<wait>",
-    "load_video",
-    "<enter><wait>",
-    "set gfxpayload=keep",
-    "<enter><wait>",
-    "insmod gzio",
-    "<enter><wait>",
-    "linux ($root)/vmlinuz-5.14.0-427.16.1.el9_4.x86_64 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0 root=LABEL=rocky ds=nocloud-net';'s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/",
-    "<enter><wait>",
-    "initrd ($root)/initramfs-5.14.0-427.16.1.el9_4.x86_64.img",
-    "<enter><wait>",
-    "boot",
-    "<enter><wait>"
-  ]
 }

--- a/sources-qemu.pkr.hcl
+++ b/sources-qemu.pkr.hcl
@@ -16,7 +16,7 @@ source "qemu" "dn" {
 }
 
 source "qemu" "rl" {
-  iso_url      = "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2"
+  iso_url      = "https://dl.rockylinux.org/vault/rocky/9.3/images/x86_64/Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2"
   iso_checksum = "sha256:7713278c37f29b0341b0a841ca3ec5c3724df86b4d97e7ee4a2a85def9b2e651"
   disk_image   = true
   headless     = true

--- a/sources-qemu.pkr.hcl
+++ b/sources-qemu.pkr.hcl
@@ -16,8 +16,8 @@ source "qemu" "dn" {
 }
 
 source "qemu" "rl" {
-  iso_url      = "https://dl.rockylinux.org/pub/rocky/9.4/images/x86_64/Rocky-9-GenericCloud-Base-9.4-20240509.0.x86_64.qcow2"
-  iso_checksum = "sha256:2b521fdff4e4d1a0f1a10b53579a34bba8081ce5eb08e64e3ff22289557f0cfa"
+  iso_url      = "https://dl.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud-Base-9.3-20231113.0.x86_64.qcow2"
+  iso_checksum = "sha256:7713278c37f29b0341b0a841ca3ec5c3724df86b4d97e7ee4a2a85def9b2e651"
   disk_image   = true
   headless     = true
   cpu_model    = "host"


### PR DESCRIPTION
The `cloud-init` shipped with Rocky Linux 9.4 has a bug that prevents the correct pass of the `cloud-init` configuration at boot time via the `smbios` qemu parameter. As a workaround, the process of image creation follows these steps:
* Start from Rocky Linux 9.3
* Lock the version for the `cloud-init` package to prevent the update and the encounter of the bug
* Install NS8, which will also update to Rocky Linux 9.4
* Remove the lock on the `cloud-init` version
In this way, the images can be used on platforms that use the `smbios` mechanism to pass the cloud-init configuration.
